### PR TITLE
feat. Optional mailing when bags are full

### DIFF
--- a/conf/mod_aoe_loot.conf.dist
+++ b/conf/mod_aoe_loot.conf.dist
@@ -24,3 +24,13 @@
 #
 
 AOELoot.Enable = 1
+
+#
+#   AOELoot.MailEnable
+#       Description: Enables the sending of mail if there are no spaces in the bags.
+#       Default:    1 (Enabled)
+#       Possible values:    0 - (Disabled)
+#                           1 - (Enabled)
+#
+
+AOELoot.MailEnable = 1

--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -76,7 +76,7 @@ public:
                         player->SendNotifyLootItemRemoved(lootSlot);
                         player->SendLootRelease(player->GetLootGUID());
                     }
-                    else
+                    else if (sConfigMgr->GetOption<bool>("AOELoot.MailEnable", true))
                     {
                         player->SendItemRetrievalMail(item->itemid, item->count);
                         ChatHandler(player->GetSession()).SendSysMessage(AOE_ITEM_IN_THE_MAIL);


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- An option has been added in the configuration file to prevent or allow the sending of mails when checking that the player's bags are full.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/13

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. You create a character
2. You start collecting different items or you fill the available bags.
3. Configure the variable, so that it does not enable the sending of mails.
4. When it detects that the bags are full, it will not lift the item (it will be deleted for the moment, then we will correct it) but it will not send the mail with the items.
