### PR TITLE
Feat. Preventing the procurement of multiple unique items

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -71,15 +71,29 @@ public:
             {
                 if (LootItem* item = loot->LootItemInSlot(i, player))
                 {
-                    if (player->AddItem(item->itemid, item->count))
+                    ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(item->itemid);
+
+                    if (itemTemplate->MaxCount != 1)
                     {
+                        if (player->AddItem(item->itemid, item->count))
+                        {
+                            player->SendNotifyLootItemRemoved(lootSlot);
+                            player->SendLootRelease(player->GetLootGUID());
+                        }
+                        else if (sConfigMgr->GetOption<bool>("AOELoot.MailEnable", true))
+                        {
+                            player->SendItemRetrievalMail(item->itemid, item->count);
+                            ChatHandler(player->GetSession()).SendSysMessage(AOE_ITEM_IN_THE_MAIL);
+                        }
+                    }
+                    else
+                    {
+                        if (!player->HasItemCount(item->itemid, 1))
+                        {
+                            player->AddItem(item->itemid, item->count);
+                        }
                         player->SendNotifyLootItemRemoved(lootSlot);
                         player->SendLootRelease(player->GetLootGUID());
-                    }
-                    else if (sConfigMgr->GetOption<bool>("AOELoot.MailEnable", true))
-                    {
-                        player->SendItemRetrievalMail(item->itemid, item->count);
-                        ChatHandler(player->GetSession()).SendSysMessage(AOE_ITEM_IN_THE_MAIL);
                     }
                 }
             }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- As explained in the title of the pull request, the idea is to prevent an item from being retrieved multiple times in case it is unique. Currently, if a person kills a series of npc, and many have a unique item in the available loot, the player takes one and checks the rest of the items by mail. 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/15

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Locate some npc, who can get to grant a unique item, and check that the player only gets 1, although there may be many within the bodies to be looted.


https://github.com/azerothcore/mod-aoe-loot/assets/2810187/3deb19b2-32e0-4b0b-a193-358d5cc2c69c

https://github.com/azerothcore/mod-aoe-loot/assets/2810187/53acd0af-587d-46d6-a13b-e9187c46f645