### PR TITLE
feat. Allow area loot if loot is free

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -50,7 +50,7 @@ public:
     {
         bool _enable = sConfigMgr->GetOption<bool>("AOELoot.Enable", true);
 
-        if (player->GetGroup() || !_enable)
+        if (player->GetGroup() && player->GetGroup()->GetLootMethod() != FREE_FOR_ALL || !_enable)
             return;
 
         float range = 30.0f;

--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -50,7 +50,7 @@ public:
     {
         bool _enable = sConfigMgr->GetOption<bool>("AOELoot.Enable", true);
 
-        if (player->GetGroup() && player->GetGroup()->GetLootMethod() != FREE_FOR_ALL || !_enable)
+        if ((player->GetGroup() && (player->GetGroup()->GetLootMethod() != FREE_FOR_ALL)) || !_enable)
             return;
 
         float range = 30.0f;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- With this change, it is allowed, despite being in a group, to be able to obtain items in the area, as long as the loot condition is: free loot. By enabling this, 2 or more people, who are in a group, if they configure the loot as free, will be able to loot faster, although only 1 of the group members will take the rewards.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a group of 2 or more people
2. Kill several enemies, and they will not be able to access the loot in the area
3. Then, change the option to free loot, and then area loot will work.
