### PR TITLE
feat. Modifying the module logic

### DIFF
--- a/conf/mod_aoe_loot.conf.dist
+++ b/conf/mod_aoe_loot.conf.dist
@@ -34,3 +34,11 @@ AOELoot.Enable = 1
 #
 
 AOELoot.MailEnable = 1
+
+#
+#   AOELoot.Range
+#       Description: Maximum reach range search loot.
+#       Default:    30.0
+#
+
+AOELoot.Range = 30.0

--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -53,7 +53,8 @@ public:
         if (!_enable)
             return;
 
-        float range = 30.0f;
+        float range = sConfigMgr->GetOption<float>("AOELoot.Range", 30.0);
+
         uint32 gold = 0;
 
         std::list<Creature*> creaturedie;

--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -84,7 +84,6 @@ public:
                 Loot* loot = &_creature->loot;
                 gold += loot->gold;
                 loot->gold = 0;
-                uint8 lootSlot = 0;
 
                 for (auto const& item : loot->items)
                 {

--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -61,9 +61,18 @@ public:
 
         for (auto const& _creature : creaturedie)
         {
-            if (player->GetGroup() && (player->GetGroup()->GetMembersCount()) > 1)
-                if (_creature->IsDungeonBoss() || _creature->isWorldBoss())
-                    continue;
+            if (player->GetGroup())
+            {
+                if (player->GetGroup()->GetMembersCount() > 1)
+                {
+                    if (_creature->IsDungeonBoss() || _creature->isWorldBoss())
+                        continue;
+                }
+                else if (player->GetGroup()->GetMembersCount() == 1)
+                {
+                    player->GetGroup()->SetLootMethod(FREE_FOR_ALL);
+                }
+            }
 
             if (player == _creature->GetLootRecipient())
             {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Area loot is enabled for groups
- If the group has more than one person, the bosses must be stripped manually (To ensure that the roll is carried out normally)
- The area loot now divides the gold between the group members
- The player can only loot the bodies whose loot belongs to him.
- If the player is alone, the loot is automatically set to free loot ([imevul](https://github.com/imevul))
- The range can be modified in the configuration file, the default is 30, but it can be increased or decreased.
- The items are stored, and then all are delivered at the end, allowing the totals to be visible

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. You can create a group, or enter a dungeon alone through the mod-solo-lfg module and complete the dungeon normally, obtaining the items.
2. For this change to work, it is still necessary to make a change to the emulator. So this change alone is not enough.