### PR TITLE
Fix. Give the player the quest items too

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -101,7 +101,11 @@ public:
                         if (!player->HasItemCount(item.itemid, 1, true))
                             aoeLoot[item.itemid] = 1;
                     }
-                    player->SendNotifyLootItemRemoved(item.itemIndex);
+                }
+
+                for (auto const& item : loot->quest_items)
+                {
+                    aoeLoot[item.itemid] += (uint32)item.count;
                 }
 
                 player->SendLootRelease(player->GetLootGUID());


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Due to some problems that we were having when obtaining the items, and seeing that in some situations we were obtaining more items than expected, some changes were made, and this problem was corrected. However, we are going through the list of common items, not the quests, therefore, these items were eliminated, without doing anything about it.
- Although this modification is not perfect, for the moment, it solves the problem, and also allows us to control the issue that in some circumstances, more items are awarded than necessary (it causes frost cloths, for example). However, the code is not perfect, and surely improvements can continue to be made. Such as the fact of detecting that the player has already completed the quest, eliminating the inventory items that are left over when delivering it or controlling, that no more items are given than the quest requires.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/24

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Take a quest, which requires collecting some item from a dead npc.
2. Check the nearby bodies, counting the items and seeing that you obtain the amount that would be obtained, if the module were not used and the item was obtained, body by body.