### PR TITLE
fix. Delete quest items after completing it

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -193,6 +193,26 @@ public:
     {
         OnCreatureLootAOE(player);
     }
+
+    /*
+    * This function is responsible for deleting the player's leftover items.
+    * But it only deletes those that are from a quest, and that cannot be obtained if the quest were not being carried out.
+    * Since there are some items that can be obtained even if you are not doing a quest.
+    */
+
+    void OnPlayerCompleteQuest(Player* player, Quest const* quest) override
+    {
+        for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
+        {
+            if (ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate(quest->RequiredItemId[i]))
+            {
+                if ((itemTemplate->Bonding == BIND_QUEST_ITEM) && (!quest->IsRepeatable()))
+                {
+                    player->DestroyItemCount(quest->RequiredItemId[i], 9999, true);
+                }
+            }
+        }
+    }
 };
 
 void AddSC_AoeLoot()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Currently, when adding items to the player's bag, it may happen that the player obtains more items than the quest needs. Therefore, when it is completed, the items must be removed from the bag, and from the player's bank.
- We are only going to eliminate certain items. Because there are some, I know that they can be obtained and used in missions, which do not have to be eliminated, since they can be sold and traded with them.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a character or choose a quest that requires items from an NPC.
2. Obtain more items from the account, and complete the mission. As an additional bonus, you can leave part of the items in the bank, to verify that they are also eliminated.
3. Upon completing the quest and obtaining the reward, the items in the player's bag and bank are eliminated. (the leftovers).

Items, whose boding is 0, are not deleted.
Only those that have the same one with the value 4.

```
 entry  name                                   bonding  
------  -------------------------------------  ---------
  2725  Green Hills of Stranglethorn - Page 1          0
  3901  Bloodscalp Tusk                                4
  8483  Wastewander Water Pouch                        0
 29906  Vashj's Vial Remnant                           4
 50432  Diseased Wolf Pelt                             4
```