### PR TITLE
fix. Allow the player to skin the creature

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -117,11 +117,6 @@ public:
                         _creature->AllLootRemovedFromCorpse();
                         _creature->RemoveFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
                         loot->clear();
-
-                        if (_creature->HasUnitFlag(UNIT_FLAG_SKINNABLE))
-                        {
-                            _creature->RemoveUnitFlag(UNIT_FLAG_SKINNABLE);
-                        }
                     }
                 }
                 else


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- By eliminating this line, we allow the player who has the skinning ability to obtain the creature's hide. When I added this line, what I wanted to prevent is the skinning from becoming infinite, however, I was testing it, and once you get the skin, the body disappears. However, it can fail, and the body remains in place, until you try again and if you manage to obtain the leather, the body is only eliminated there.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/19

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a character with the skinning skill.
2. Once all the items are obtained, try to skin the creature, and if successful, it should disappear.
3. If you fail, the body continues, so you can try again, and when you succeed, the body disappears.