### PR TITLE
fix. Close the loot bag when taking the gold

### DIFF
--- a/src/AoeLoot_SC.cpp
+++ b/src/AoeLoot_SC.cpp
@@ -53,17 +53,15 @@ public:
         if (!_enable)
             return;
 
-        std::list<Creature*> deadCreatures;
-
         float range = sConfigMgr->GetOption<float>("AOELoot.Range", 30.0);
 
+        std::list<Creature*> deadCreatures;
         uint32 gold = 0;
-
         player->GetDeadCreatureListInGrid(deadCreatures, range);
+        ObjectGuid lootGuid = player->GetLootGUID();
 
         for (auto& _creature : deadCreatures)
         {
-            ObjectGuid lootGuid = player->GetLootGUID();
             Loot* loot = &_creature->loot;
             gold += loot->gold;
             loot->gold = 0;
@@ -81,6 +79,10 @@ public:
                     loot->unlootedCount--;
 
                     player->SendItemRetrievalMail(lootItem->itemid, lootItem->count);
+                }
+                else
+                {
+                    player->SendLootRelease(lootGuid);
                 }
             }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- As described in the video, currently, due to the latest changes, we were missing closing the loot bag to the player, when the loot is gold. It's a visual error, however, we had to correct it anyway. I didn't add extra gold or anything like that, but it's not okay for the bag to be left open after taking the loot. It only happened with the client's auto stripping activated, because if the auto stripping was not there, there were no problems.
- I moved some pointers around, just so they are all together, but I don't think they change the logic of the problem.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/32

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. With 1 account alone or with 2 people in a group, kill a series of enemies, and activate the automatic looting of the client.
2. You should get all the items in the bag, and the loot menu should close.