### PR TITLE
fix. Failed to skin looted creature

### DIFF
--- a/src/aoe_loot.h
+++ b/src/aoe_loot.h
@@ -30,7 +30,7 @@ enum AoeLootString
     AOE_ITEM_IN_THE_MAIL
 };
 
-void OnCreatureLootAOE(Player* player);
+void OnCreatureLootAOE(Player* player, ObjectGuid lootguid);
 
 class AoeLootPlayer : public PlayerScript
 {
@@ -39,7 +39,7 @@ public:
 
     void OnLogin(Player* player) override;
     bool CanSendErrorAlreadyLooted(Player* /*player*/) override;
-    void OnAfterCreatureLoot(Player* player) override;
+    void OnLootItem(Player* player, Item* /*item*/, uint32 /*count*/, ObjectGuid lootguid) override;
     void OnBeforeLootMoney(Player* player, Loot* /*loot*/) override;
     void OnPlayerCompleteQuest(Player* player, Quest const* quest) override;
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Currently, when you kill a group of creatures, and proceed to loot, for some reason, the first to be looted fails the skinning, even if the player's skill is high or even 450 (the maximum).
- Area loot is interrupted if what is being skinned is different from a creature. This is in order to prevent the script from being executed on the bodies, when they are close to an ore, or chest or other element. The script should only be used when what is being obtained is the item from the body of a creature or at least, initially that was the original idea.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game

Example looting high level creature. Applying skinning.

https://github.com/azerothcore/mod-aoe-loot/assets/2810187/ed03ff7a-4f22-431b-b166-01e345a0b719

This is the result, with low level creatures. But stripping and skinning the first of them.

https://github.com/azerothcore/mod-aoe-loot/assets/2810187/515ad6ce-cfc3-4d1c-ab8e-0d97ddc250ac

Finally, we have the same as above. But skinning someone other than the first to loot.

https://github.com/azerothcore/mod-aoe-loot/assets/2810187/b36983b7-20cc-42da-8c3e-6b18b4e9e9b7