### PR TITLE
chore. Enable or disable message when logging in

### DIFF
--- a/conf/mod_aoe_loot.conf.dist
+++ b/conf/mod_aoe_loot.conf.dist
@@ -26,6 +26,15 @@
 AOELoot.Enable = 1
 
 #
+#    AOELoot.Message
+#         Description: Enable message on login
+#         Default:    0 - (Disabled)
+#                     1 - (Enabled)
+#
+
+AOELoot.Message = 1
+
+#
 #   AOELoot.MailEnable
 #       Description: Enables the sending of mail if there are no spaces in the bags.
 #       Default:    1 (Enabled)

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -116,7 +116,8 @@ void AoeLootPlayer::OnLogin(Player* player)
 {
     if (sConfigMgr->GetOption<bool>("AOELoot.Enable", true))
     {
-        ChatHandler(player->GetSession()).PSendSysMessage(AOE_ACORE_STRING_MESSAGE);
+        if (sConfigMgr->GetOption<bool>("AOELoot.Message", true))
+            ChatHandler(player->GetSession()).PSendSysMessage(AOE_ACORE_STRING_MESSAGE);
     }
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- A configuration variable is created, which allows to hide the message about the module when accessing the server.
- By default, the message is displayed.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/39

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Download changes
2. Disable the configuration variable
3. When you log in, you should not see the message
4. You could also use `reload config`