### PR TITLE
fix: correct group loot item ownership and rewrite using OnPlayerCreatureLootOpened hook

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -8,263 +8,134 @@
 
 ## Description
 
-This module enables Area of Effect (AOE) looting functionality for AzerothCore, allowing players to loot multiple nearby corpses by interacting with just one of them. All items and gold from corpses within the configured range are automatically collected into a single loot window.
-
-## Features
-
-- **AOE Looting**: Automatically collect loot from multiple nearby corpses with a single interaction
-- **Player Toggle Commands**: Individual players can enable/disable AOE loot using `.aoeloot on/off` commands
-- **Multi-language Support**: Full internationalization support with English and Spanish translations (easily extensible to other languages)
-- **Configurable Range**: Server administrators can set the maximum distance for AOE loot collection
-- **Group Support**: Optional group looting with configurable settings
-- **Performance Optimized**: Limits number of corpses processed to maintain server stability
-- **Smart Item Management**:
-  - Automatic gold accumulation with overflow protection
-  - Quest items sent directly to inventory
-  - Maximum 15 items per loot window to prevent UI issues
-- **Corpse Management**: Automatically cleans up looted corpses to reduce clutter
-
-## Recent Updates
-
-### v2.0 - Player Control & Internationalization
-- ✅ Added `.aoeloot on/off` player commands for individual control
-- ✅ Implemented multi-language support via `acore_string` system
-- ✅ Fixed enum ID alignment issues
-- ✅ Complete English and Spanish translations
-- ✅ Improved code documentation and structure
-
-### v1.x - Core Functionality
-- Initial AOE loot implementation
-- Configuration system
-- Range and group settings
+This module enables Area of Effect (AOE) looting for AzerothCore. When a player loots a corpse, all nearby eligible corpses are automatically looted as well — items land directly in the player's bags without requiring individual clicks on each body.
 
 ## Requirements
 
-- AzerothCore v3.0.0+ (latest master branch recommended)
-- MySQL 8.0+
-- Compiler with C++17 support
+- AzerothCore latest master branch
+- Core PR [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) merged *(adds the `OnPlayerCreatureLootOpened` hook and `Player::AutoTakeCreatureLoot` used by this module)*
 
 ## Installation
 
-### 1. Clone the Module
+### 1. Apply the core PR
 
-Navigate to your AzerothCore modules directory:
+This module depends on two additions to the AzerothCore core. Ensure the linked PR above is merged before compiling.
+
+### 2. Clone the module
 
 ```bash
 cd <ACoreDir>/modules
 git clone https://github.com/azerothcore/mod-aoe-loot.git
 ```
 
-### 2. Compile
-
-Re-compile AzerothCore:
+### 3. Recompile AzerothCore
 
 ```bash
 cd <ACoreDir>/build
-cmake ../ -DCMAKE_INSTALL_PREFIX=/path/to/server -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
-make -j $(nproc)
-make install
+cmake .. && make -j$(nproc) && make install
 ```
 
-### 3. Configure
+### 4. Configure
 
-Edit your `worldserver.conf` file (or create `AOELoot.conf` in configs folder):
+Copy `conf/mod_aoe_loot.conf.dist` to your server's config directory and adjust the values as needed (see **Configuration** below).
 
-```conf
-###################################################################################################
-#    AOE LOOT MODULE CONFIGURATION
-###################################################################################################
+### 5. Restart the worldserver
 
-#
-#    AOELoot.Enable
-#        Description: Enable or disable the AOE Loot module globally
-#        Default:     1 (enabled)
-#                     0 (disabled)
+---
 
-AOELoot.Enable = 1
+## How it works
 
-#
-#    AOELoot.Range
-#        Description: Maximum distance (in yards) to collect loot from nearby corpses
-#        Default:     55.0
-#        Range:       5.0 - 100.0
+When a player loots any corpse:
 
-AOELoot.Range = 55.0
+1. The server applies its normal loot rules to that corpse (round-robin assignment, roll setup, etc.).
+2. The module scans for nearby lootable corpses within the configured range.
+3. For each eligible nearby corpse, the module calls the server's internal loot-take routine on behalf of the player. Items the player is entitled to go directly into their bags; the normal loot window remains open only for the corpse the player actually clicked.
 
-#
-#    AOELoot.Group
-#        Description: Allow AOE looting when player is in a group
-#        Default:     1 (allowed)
-#                     0 (not allowed)
+Items arrive in inventory with the standard "You receive loot" notification — no extra loot windows, no merging.
 
-AOELoot.Group = 1
+---
 
-#
-#    AOELoot.Message
-#        Description: Show informational message on player login
-#        Default:     1 (show message)
-#                     0 (no message)
+## Group loot behavior
 
-AOELoot.Message = 1
+> **Important for server administrators and players**
 
-###################################################################################################
-```
+This module fully respects the group loot method configured for the party.
 
-### 4. Corpse Decay Configuration (IMPORTANT)
+### Group Loot / Round Robin / Need Before Greed
 
-For optimal experience, modify the corpse decay settings in `worldserver.conf`:
+The server assigns each corpse to a specific group member via its round-robin rotation (set at creature death, before any player opens the loot). The module honors this assignment:
 
-```conf
-#
-#    Rate.Corpse.Decay.Looted
-#        Description: Multiplier for Corpse.Decay.* to configure how long creature corpses stay
-#                     after they have been looted.
-#        Default:     0.5
-#        Recommended: 0.01 (for AOE Loot module)
+- **Each player auto-collects only the corpses assigned to them** by the round-robin. Other members' corpses are left untouched and remain lootable.
+- **Items go directly to the assigned player's bags**, even if that player has not clicked on the corpse yet. This happens automatically when any group member loots nearby.
+- **If a player manually opens a corpse assigned to another member**, the rightful owner's items are immediately and silently sent to their bags before the opener can interact with the loot window. The opener receives nothing from that corpse.
 
-Rate.Corpse.Decay.Looted = 0.01
-```
+In practice: each player needs to loot at least one corpse to trigger the auto-collection of all the corpses assigned to them. Players will find items appearing in their bags from corpses they never clicked.
 
-**Why this is important:** The default decay rate (0.5) can cause corpses to linger after being looted via AOE, creating visual clutter. Setting this to 0.01 ensures corpses disappear quickly after looting.
+### Free For All
 
-### 5. Restart Server
+All group members collect from all nearby eligible corpses without restriction.
 
-Restart your worldserver to load the module:
+### Master Loot
 
-```bash
-./worldserver
-```
+The master looter auto-collects all nearby eligible corpses.
 
-## Usage
+---
 
-### For Players
+## Player commands
 
-#### Commands
-- `.aoeloot on` - Enable AOE looting for your character
-- `.aoeloot off` - Disable AOE looting for your character
+| Command | Description |
+|---------|-------------|
+| `.aoeloot on` | Enable AOE looting for your character |
+| `.aoeloot off` | Disable AOE looting for your character |
 
-#### How to Use
-1. Kill multiple enemies in close proximity
-2. Right-click on any corpse to loot
-3. All items from nearby corpses will appear in a single loot window
-4. Quest items are automatically added to your inventory
+> Player preferences reset on logout. AOE loot is enabled by default when the module is active.
 
-**Note:** Player preferences reset on logout. AOE loot is enabled by default if the module is active.
+---
 
-### For Administrators
-
-The module can be controlled through configuration file settings (see Configuration section above).
-
-## Configuration Options
+## Configuration
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `AOELoot.Enable` | Boolean | 1 | Enable/disable module globally |
-| `AOELoot.Range` | Float | 55.0 | Maximum loot collection radius (5.0 - 100.0) |
-| `AOELoot.Group` | Boolean | 1 | Allow AOE loot in groups |
-| `AOELoot.Message` | Boolean | 1 | Show login message |
+| `AOELoot.Enable` | Boolean | 1 | Enable or disable the module globally |
+| `AOELoot.Message` | Boolean | 1 | Show informational message on player login |
+| `AOELoot.Range` | Float | 55.0 | Maximum search radius in yards (5.0 – 100.0) |
+| `AOELoot.Group` | Boolean | 1 | Enable AOE loot when the player is in a group |
+| `AOELoot.MaxCorpses` | Integer | 20 | Maximum nearby corpses processed per loot trigger (1 – 50) |
 
-## Multi-language Support
+### Recommended: faster corpse decay
 
-The module includes full multi-language support through AzerothCore's `acore_string` system.
+To avoid visual clutter from looted corpses lingering on the ground, reduce the decay rate in `worldserver.conf`:
 
-### Currently Supported Languages
-- 🇬🇧 English (en_US)
-- 🇪🇸 Spanish (es_ES / es_MX)
-
-### Adding More Languages
-
-To add additional language support, update the SQL file:
-
-```sql
-UPDATE `acore_string` SET
-    `locale_frFR` = 'Votre traduction ici',
-    `locale_deDE` = 'Ihre Übersetzung hier',
-    `locale_ruRU` = 'Ваш перевод здесь'
-WHERE `entry` BETWEEN 50000 AND 50007;
+```conf
+# Default: 0.5 — Recommended for AOE loot: 0.01
+Rate.Corpse.Decay.Looted = 0.01
 ```
 
-Supported locale columns:
-- `locale_koKR` (Korean)
-- `locale_frFR` (French)
-- `locale_deDE` (German)
-- `locale_zhCN` (Chinese Simplified)
-- `locale_zhTW` (Chinese Traditional)
-- `locale_ruRU` (Russian)
-
-## Technical Details
-
-### Database Entries
-
-The module uses `acore_string` entries 50000-50007:
-
-| Entry | Constant | Purpose |
-|-------|----------|---------|
-| 50000 | AOE_ACORE_STRING_MESSAGE | Login message |
-| 50001 | AOE_ITEM_IN_THE_MAIL | Mail notification (reserved) |
-| 50002-50003 | - | Reserved for future use |
-| 50004 | AOE_LOOT_ALREADY_ENABLED | "Already enabled" message |
-| 50005 | AOE_LOOT_ENABLED | "Enabled" confirmation |
-| 50006 | AOE_LOOT_ALREADY_DISABLED | "Already disabled" message |
-| 50007 | AOE_LOOT_DISABLED | "Disabled" confirmation |
-
-### Performance Considerations
-
-- Maximum 10 corpses processed per loot operation (hardcoded for stability)
-- Maximum 15 items per loot window
-- Gold overflow protection (prevents exceeding uint32 max value)
-- Efficient corpse filtering and cleanup
+---
 
 ## Troubleshooting
 
-### Issue: AOE loot not working
+| Issue | Solution |
+|-------|----------|
+| AOE loot not triggering | Verify `AOELoot.Enable = 1` and `.aoeloot on` for your character |
+| Only one corpse looted | Check that the core PR is applied and the server is recompiled |
+| Items not going to the right player | Confirm the group loot method is set before combat |
+| Corpses not disappearing | Set `Rate.Corpse.Decay.Looted = 0.01` in `worldserver.conf` |
 
-**Solutions:**
-- Verify module is enabled: `AOELoot.Enable = 1`
-- Check if you disabled it personally: use `.aoeloot on`
-- Ensure you're within range (default 55 yards)
-- If in group, check `AOELoot.Group` setting
+---
 
-### Issue: Corpses not disappearing
+## Known limitations
 
-**Solution:**
-- Set `Rate.Corpse.Decay.Looted = 0.01` in worldserver.conf
+- Player toggle preferences (`.aoeloot on/off`) do not persist across logout/login.
+- AOE loot triggers only when a player loots a corpse; idle players near a fight do not collect automatically.
 
-### Issue: Messages in wrong language
-
-**Solution:**
-- Verify SQL was imported correctly
-- Check client locale settings
-- Confirm `acore_string` table has translations for your locale
-
-### Issue: "Already enabled/disabled" messages appearing incorrectly
-
-**Solution:**
-- This is expected behavior - preferences reset on logout
-- On first login, AOE loot is enabled by default
-
-## Known Limitations
-
-- Player preferences do not persist across logout/login sessions
-- Maximum 10 corpses processed at once (performance limit)
-- Quest items sent to inventory may fill bags quickly
-- Range limited to 100 yards maximum
-
-## Future Enhancements
-
-Potential features for future versions:
-- [ ] Database persistence for player preferences
-- [ ] Configurable max corpses limit
-- [ ] Quest item mail option (instead of direct inventory)
-- [ ] Visual range indicator
-- [ ] Per-character settings UI
-- [ ] Statistics tracking (total items/gold looted)
+---
 
 ## Credits
 
-- **acidmanifesto** - [Original author and concept](https://github.com/azerothcore/mod-aoe-loot/pull/2)
-- **AzerothCore Community** - Hooks, updates, and improvements
-- **Contributors** - Player commands, multi-language support, and bug fixes
+- **acidmanifesto** — [Original author and concept](https://github.com/azerothcore/mod-aoe-loot/pull/2)
+- **AzerothCore Community** — Hooks, updates, and improvements
+- **Contributors** — Player commands, multi-language support, and bug fixes
 
 ## Links
 
@@ -275,20 +146,3 @@ Potential features for future versions:
 ## License
 
 This module is released under the [GNU AGPL v3 License](https://github.com/azerothcore/mod-aoe-loot/blob/master/LICENSE).
-
----
-
-### Support
-
-If you encounter any issues or have suggestions:
-1. Check the [Troubleshooting](#troubleshooting) section
-2. Search [existing issues](https://github.com/azerothcore/mod-aoe-loot/issues)
-3. Join the [AzerothCore Discord](https://discord.gg/PaqQRkd)
-4. Create a [new issue](https://github.com/azerothcore/mod-aoe-loot/issues/new) with detailed information
-
-**Please include:**
-- AzerothCore commit hash
-- Operating system and version
-- Complete error messages (if any)
-- Configuration settings
-- Steps to reproduce the issue

--- a/.github/README.md
+++ b/.github/README.md
@@ -13,13 +13,13 @@ This module enables Area of Effect (AOE) looting for AzerothCore. When a player 
 ## Requirements
 
 - AzerothCore latest master branch
-- Core PR [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) merged *(adds the `OnPlayerCreatureLootOpened` hook and `Player::AutoTakeCreatureLoot` used by this module)*
+- Core PR [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) merged *(adds the `OnPlayerCreatureLootOpened` hook used by this module)*
 
 ## Installation
 
 ### 1. Apply the core PR
 
-This module depends on two additions to the AzerothCore core. Ensure the linked PR above is merged before compiling.
+This module depends on the `OnPlayerCreatureLootOpened` hook added to the AzerothCore core. Ensure the linked PR above is merged before compiling.
 
 ### 2. Clone the module
 

--- a/.github/README_ES.md
+++ b/.github/README_ES.md
@@ -13,13 +13,13 @@ Este módulo habilita el saqueo en área (AOE) para AzerothCore. Cuando un jugad
 ## Requisitos
 
 - AzerothCore rama master (versión reciente)
-- PR del core [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) aplicado *(agrega el hook `OnPlayerCreatureLootOpened` y el método `Player::AutoTakeCreatureLoot` utilizados por este módulo)*
+- PR del core [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) aplicado *(agrega el hook `OnPlayerCreatureLootOpened` utilizado por este módulo)*
 
 ## Instalación
 
 ### 1. Aplicar el PR del core
 
-Este módulo depende de dos adiciones al core de AzerothCore. Asegurarse de que el PR indicado arriba esté aplicado antes de compilar.
+Este módulo depende del hook `OnPlayerCreatureLootOpened` añadido al core de AzerothCore. Asegurarse de que el PR indicado arriba esté aplicado antes de compilar.
 
 ### 2. Clonar el módulo
 

--- a/.github/README_ES.md
+++ b/.github/README_ES.md
@@ -8,286 +8,141 @@
 
 ## Descripción
 
-Este módulo habilita la funcionalidad de saqueo en área (AOE) para AzerothCore, permitiendo a los jugadores saquear múltiples cadáveres cercanos interactuando con solo uno de ellos. Todos los objetos y oro de los cadáveres dentro del rango configurado se recopilan automáticamente en una sola ventana de botín.
-
-## Características
-
-- **Saqueo AOE**: Recolecta automáticamente el botín de múltiples cadáveres cercanos con una sola interacción
-- **Comandos de Activación Individual**: Los jugadores pueden activar/desactivar el saqueo AOE usando los comandos `.aoeloot on/off`
-- **Soporte Multi-idioma**: Internacionalización completa con traducciones en inglés y español (fácilmente extensible a otros idiomas)
-- **Rango Configurable**: Los administradores del servidor pueden establecer la distancia máxima para la recolección de botín AOE
-- **Soporte de Grupo**: Saqueo en grupo opcional con configuración personalizable
-- **Optimizado para Rendimiento**: Limita el número de cadáveres procesados para mantener la estabilidad del servidor
-- **Gestión Inteligente de Objetos**:
-  - Acumulación automática de oro con protección contra desbordamiento
-  - Objetos de misión enviados directamente al inventario
-  - Máximo de 15 objetos por ventana de botín para evitar problemas de interfaz
-- **Gestión de Cadáveres**: Limpia automáticamente los cadáveres saqueados para reducir el desorden visual
-
-## Actualizaciones Recientes
-
-### v2.0 - Control del Jugador e Internacionalización
-- ✅ Agregados comandos `.aoeloot on/off` para control individual del jugador
-- ✅ Implementado soporte multi-idioma mediante el sistema `acore_string`
-- ✅ Corregidos problemas de alineación de IDs en enums
-- ✅ Traducciones completas en inglés y español
-- ✅ Mejorada la documentación y estructura del código
-
-### v1.x - Funcionalidad Principal
-- Implementación inicial del saqueo AOE
-- Sistema de configuración
-- Ajustes de rango y grupo
+Este módulo habilita el saqueo en área (AOE) para AzerothCore. Cuando un jugador saquea un cadáver, todos los cadáveres cercanos elegibles se saquean automáticamente — los objetos van directamente a la bolsa del jugador sin necesidad de hacer clic en cada cuerpo individualmente.
 
 ## Requisitos
 
-- AzerothCore v3.0.0+ (se recomienda la última rama master)
-- MySQL 8.0+
-- Compilador con soporte para C++17
+- AzerothCore rama master (versión reciente)
+- PR del core [feat/player-creature-loot-opened-hook](https://github.com/azerothcore/azerothcore-wotlk/pull/XXXX) aplicado *(agrega el hook `OnPlayerCreatureLootOpened` y el método `Player::AutoTakeCreatureLoot` utilizados por este módulo)*
 
 ## Instalación
 
-### 1. Clonar el Módulo
+### 1. Aplicar el PR del core
 
-Navega al directorio de módulos de AzerothCore:
+Este módulo depende de dos adiciones al core de AzerothCore. Asegurarse de que el PR indicado arriba esté aplicado antes de compilar.
+
+### 2. Clonar el módulo
 
 ```bash
-cd <DirectorioACore>/modules
+cd <ACoreDir>/modules
 git clone https://github.com/azerothcore/mod-aoe-loot.git
 ```
 
-### 2. Compilar
-
-Recompila AzerothCore:
+### 3. Recompilar AzerothCore
 
 ```bash
-cd <DirectorioACore>/build
-cmake ../ -DCMAKE_INSTALL_PREFIX=/ruta/al/servidor -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
-make -j $(nproc)
-make install
+cd <ACoreDir>/build
+cmake .. && make -j$(nproc) && make install
 ```
 
-### 3. Configurar
+### 4. Configurar
 
-Edita tu archivo `worldserver.conf` (o crea `AOELoot.conf` en la carpeta de configuraciones):
+Copiar `conf/mod_aoe_loot.conf.dist` al directorio de configuración del servidor y ajustar los valores según sea necesario (ver **Configuración** más abajo).
 
-```conf
-###################################################################################################
-#    CONFIGURACIÓN DEL MÓDULO AOE LOOT
-###################################################################################################
-
-#
-#    AOELoot.Enable
-#        Descripción: Habilita o deshabilita el módulo AOE Loot globalmente
-#        Por defecto:  1 (habilitado)
-#                      0 (deshabilitado)
-
-AOELoot.Enable = 1
-
-#
-#    AOELoot.Range
-#        Descripción: Distancia máxima (en yardas) para recolectar botín de cadáveres cercanos
-#        Por defecto:  55.0
-#        Rango:        5.0 - 100.0
-
-AOELoot.Range = 55.0
-
-#
-#    AOELoot.Group
-#        Descripción: Permitir saqueo AOE cuando el jugador está en un grupo
-#        Por defecto:  1 (permitido)
-#                      0 (no permitido)
-
-AOELoot.Group = 1
-
-#
-#    AOELoot.Message
-#        Descripción: Mostrar mensaje informativo al iniciar sesión
-#        Por defecto:  1 (mostrar mensaje)
-#                      0 (sin mensaje)
-
-AOELoot.Message = 1
-
-###################################################################################################
-```
-
-### 4. Configuración de Degradación de Cadáveres (IMPORTANTE)
-
-Para una experiencia óptima, modifica la configuración de degradación de cadáveres en `worldserver.conf`:
-
-```conf
-#
-#    Rate.Corpse.Decay.Looted
-#        Descripción: Multiplicador para Corpse.Decay.* que configura cuánto tiempo permanecen
-#                     los cadáveres de las criaturas después de ser saqueados.
-#        Por defecto:  0.5
-#        Recomendado:  0.01 (para el módulo AOE Loot)
-
-Rate.Corpse.Decay.Looted = 0.01
-```
-
-**Por qué es importante:** La tasa de degradación predeterminada (0.5) puede hacer que los cadáveres permanezcan después de ser saqueados mediante AOE, creando desorden visual. Establecer esto en 0.01 asegura que los cadáveres desaparezcan rápidamente después del saqueo.
-
-### 5. Reiniciar el Servidor
-
-Reinicia tu worldserver para cargar el módulo:
-
-```bash
-./worldserver
-```
-
-## Uso
-
-### Para Jugadores
-
-#### Comandos
-- `.aoeloot on` - Activar el saqueo AOE para tu personaje
-- `.aoeloot off` - Desactivar el saqueo AOE para tu personaje
-
-#### Cómo Usar
-1. Mata múltiples enemigos en proximidad cercana
-2. Haz clic derecho en cualquier cadáver para saquear
-3. Todos los objetos de los cadáveres cercanos aparecerán en una sola ventana de botín
-4. Los objetos de misión se agregan automáticamente a tu inventario
-
-**Nota:** Las preferencias del jugador se restablecen al cerrar sesión. El saqueo AOE está habilitado por defecto si el módulo está activo.
-
-### Para Administradores
-
-El módulo puede controlarse a través de la configuración del archivo (ver sección de Configuración arriba).
-
-## Opciones de Configuración
-
-| Opción | Tipo | Por Defecto | Descripción |
-|--------|------|-------------|-------------|
-| `AOELoot.Enable` | Booleano | 1 | Habilitar/deshabilitar módulo globalmente |
-| `AOELoot.Range` | Decimal | 55.0 | Radio máximo de recolección de botín (5.0 - 100.0) |
-| `AOELoot.Group` | Booleano | 1 | Permitir saqueo AOE en grupos |
-| `AOELoot.Message` | Booleano | 1 | Mostrar mensaje de inicio de sesión |
-
-## Soporte Multi-idioma
-
-El módulo incluye soporte completo multi-idioma a través del sistema `acore_string` de AzerothCore.
-
-### Idiomas Actualmente Soportados
-- 🇬🇧 Inglés (en_US)
-- 🇪🇸 Español (es_ES / es_MX)
-
-### Agregar Más Idiomas
-
-Para agregar soporte de idiomas adicionales, actualiza el archivo SQL:
-
-```sql
-UPDATE `acore_string` SET
-    `locale_frFR` = 'Votre traduction ici',
-    `locale_deDE` = 'Ihre Übersetzung hier',
-    `locale_ruRU` = 'Ваш перевод здесь'
-WHERE `entry` BETWEEN 50000 AND 50007;
-```
-
-Columnas de localización soportadas:
-- `locale_koKR` (Coreano)
-- `locale_frFR` (Francés)
-- `locale_deDE` (Alemán)
-- `locale_zhCN` (Chino Simplificado)
-- `locale_zhTW` (Chino Tradicional)
-- `locale_ruRU` (Ruso)
-
-## Detalles Técnicos
-
-### Entradas de Base de Datos
-
-El módulo utiliza las entradas `acore_string` 50000-50007:
-
-| Entrada | Constante | Propósito |
-|---------|-----------|-----------|
-| 50000 | AOE_ACORE_STRING_MESSAGE | Mensaje de inicio de sesión |
-| 50001 | AOE_ITEM_IN_THE_MAIL | Notificación de correo (reservado) |
-| 50002-50003 | - | Reservado para uso futuro |
-| 50004 | AOE_LOOT_ALREADY_ENABLED | Mensaje "Ya activado" |
-| 50005 | AOE_LOOT_ENABLED | Confirmación "Activado" |
-| 50006 | AOE_LOOT_ALREADY_DISABLED | Mensaje "Ya desactivado" |
-| 50007 | AOE_LOOT_DISABLED | Confirmación "Desactivado" |
-
-### Consideraciones de Rendimiento
-
-- Máximo 10 cadáveres procesados por operación de saqueo (fijo para estabilidad)
-- Máximo 15 objetos por ventana de botín
-- Protección contra desbordamiento de oro (previene exceder el valor máximo uint32)
-- Filtrado y limpieza eficiente de cadáveres
-
-## Solución de Problemas
-
-### Problema: El saqueo AOE no funciona
-
-**Soluciones:**
-- Verifica que el módulo esté habilitado: `AOELoot.Enable = 1`
-- Comprueba si lo desactivaste personalmente: usa `.aoeloot on`
-- Asegúrate de estar dentro del rango (55 yardas por defecto)
-- Si estás en grupo, verifica la configuración `AOELoot.Group`
-
-### Problema: Los cadáveres no desaparecen
-**Solución:**
-- Establece `Rate.Corpse.Decay.Looted = 0.01` en worldserver.conf
-
-### Problema: Mensajes en idioma incorrecto
-
-**Solución:**
-- Verifica que el SQL se importó correctamente
-- Comprueba la configuración de localización del cliente
-- Confirma que la tabla `acore_string` tiene traducciones para tu localización
-
-### Problema: Mensajes "Ya activado/desactivado" aparecen incorrectamente
-
-**Solución:**
-- Este es el comportamiento esperado - las preferencias se restablecen al cerrar sesión
-- En el primer inicio de sesión, el saqueo AOE está habilitado por defecto
-
-## Limitaciones Conocidas
-
-- Las preferencias del jugador no persisten entre sesiones de inicio/cierre de sesión
-- Máximo 10 cadáveres procesados a la vez (límite de rendimiento)
-- Los objetos de misión enviados al inventario pueden llenar las bolsas rápidamente
-- Rango limitado a un máximo de 100 yardas
-
-## Mejoras Futuras
-
-Características potenciales para versiones futuras:
-- [ ] Persistencia en base de datos para preferencias del jugador
-- [ ] Límite configurable de cadáveres máximos
-- [ ] Opción de envío de objetos de misión por correo (en lugar de inventario directo)
-- [ ] Indicador visual de rango
-- [ ] Interfaz de configuración por personaje
-- [ ] Seguimiento de estadísticas (objetos/oro total saqueado)
-
-## Créditos
-
-- **acidmanifesto** - [Autor original y concepto](https://github.com/azerothcore/mod-aoe-loot/pull/2)
-- **Comunidad AzerothCore** - Hooks, actualizaciones y mejoras
-- **Colaboradores** - Comandos de jugador, soporte multi-idioma y correcciones de errores
-
-## Enlaces
-
-- **AzerothCore:** [Repositorio](https://github.com/azerothcore) | [Sitio Web](https://azerothcore.org/) | [Discord](https://discord.gg/PaqQRkd)
-- **Repositorio del Módulo:** [GitHub](https://github.com/azerothcore/mod-aoe-loot)
-- **Problemas y Sugerencias:** [Rastreador de Problemas](https://github.com/azerothcore/mod-aoe-loot/issues)
-
-## Licencia
-
-Este módulo se publica bajo la [Licencia GNU AGPL v3](https://github.com/azerothcore/mod-aoe-loot/blob/master/LICENSE).
+### 5. Reiniciar el worldserver
 
 ---
 
-### Soporte
+## Cómo funciona
 
-Si encuentras algún problema o tienes sugerencias:
-1. Consulta la sección [Solución de Problemas](#solución-de-problemas)
-2. Busca en [problemas existentes](https://github.com/azerothcore/mod-aoe-loot/issues)
-3. Únete al [Discord de AzerothCore](https://discord.gg/PaqQRkd)
-4. Crea un [nuevo problema](https://github.com/azerothcore/mod-aoe-loot/issues/new) con información detallada
+Cuando un jugador saquea cualquier cadáver:
 
-**Por favor incluye:**
-- Hash del commit de AzerothCore
-- Sistema operativo y versión
-- Mensajes de error completos (si los hay)
-- Configuraciones utilizadas
-- Pasos para reproducir el problema
+1. El servidor aplica sus reglas normales de loot a ese cadáver (asignación round-robin, rolls, etc.).
+2. El módulo busca cadáveres saqueables cercanos dentro del rango configurado.
+3. Para cada cadáver cercano elegible, el módulo llama a la rutina interna de toma de ítems del servidor en nombre del jugador. Los ítems a los que el jugador tiene derecho van directamente a su bolsa; la ventana de loot normal permanece abierta solo para el cadáver en el que el jugador hizo clic.
+
+Los ítems llegan al inventario con la notificación estándar "Recibes botín" — sin ventanas de loot adicionales ni merging de ítems.
+
+---
+
+## Comportamiento en grupo
+
+> **Importante para administradores de servidor y jugadores**
+
+Este módulo respeta completamente el método de botín configurado para el grupo.
+
+### Botín de Grupo / Turno Rotatorio / Necesito antes que Codicia
+
+El servidor asigna cada cadáver a un miembro específico del grupo mediante su rotación round-robin (establecida al morir la criatura, antes de que cualquier jugador abra el botín). El módulo respeta esta asignación:
+
+- **Cada jugador recolecta automáticamente solo los cadáveres que le fueron asignados** por la rotación. Los cadáveres de los demás miembros se dejan intactos y siguen siendo saqueables.
+- **Los ítems van directamente a la bolsa del jugador asignado**, incluso si ese jugador no hizo clic en el cadáver. Esto ocurre automáticamente cuando cualquier miembro del grupo saquea algo cercano.
+- **Si un jugador abre manualmente un cadáver asignado a otro miembro**, los ítems del dueño legítimo se envían inmediata y silenciosamente a su bolsa antes de que el que abrió el cadáver pueda interactuar con la ventana de botín. El que abrió el cadáver no recibe nada de él.
+
+En la práctica: cada jugador necesita saquear al menos un cadáver para activar la recolección automática de todos los cadáveres que le fueron asignados. Los jugadores verán ítems apareciendo en su bolsa provenientes de cadáveres en los que nunca hicieron clic.
+
+### Libre Para Todos
+
+Todos los miembros del grupo recolectan de todos los cadáveres cercanos elegibles sin restricciones.
+
+### Maestro del Botín
+
+El maestro del botín recolecta automáticamente todos los cadáveres cercanos elegibles.
+
+---
+
+## Comandos de jugador
+
+| Comando | Descripción |
+|---------|-------------|
+| `.aoeloot on` | Activar el saqueo AOE para tu personaje |
+| `.aoeloot off` | Desactivar el saqueo AOE para tu personaje |
+
+> Las preferencias del jugador se reinician al cerrar sesión. El saqueo AOE está activado por defecto cuando el módulo está activo.
+
+---
+
+## Configuración
+
+| Opción | Tipo | Predeterminado | Descripción |
+|--------|------|----------------|-------------|
+| `AOELoot.Enable` | Booleano | 1 | Activar o desactivar el módulo globalmente |
+| `AOELoot.Message` | Booleano | 1 | Mostrar mensaje informativo al iniciar sesión |
+| `AOELoot.Range` | Float | 55.0 | Radio máximo de búsqueda en yardas (5.0 – 100.0) |
+| `AOELoot.Group` | Booleano | 1 | Activar el saqueo AOE cuando el jugador está en grupo |
+| `AOELoot.MaxCorpses` | Entero | 20 | Máximo de cadáveres cercanos procesados por activación (1 – 50) |
+
+### Recomendado: decay de cadáveres más rápido
+
+Para evitar desorden visual con los cadáveres saqueados permaneciendo en el suelo, reducir el tiempo de desaparición en `worldserver.conf`:
+
+```conf
+# Predeterminado: 0.5 — Recomendado para saqueo AOE: 0.01
+Rate.Corpse.Decay.Looted = 0.01
+```
+
+---
+
+## Solución de problemas
+
+| Problema | Solución |
+|----------|----------|
+| El saqueo AOE no se activa | Verificar `AOELoot.Enable = 1` y `.aoeloot on` en tu personaje |
+| Solo se saquea un cadáver | Verificar que el PR del core esté aplicado y el servidor recompilado |
+| Los ítems no van al jugador correcto | Confirmar que el método de botín del grupo esté configurado antes del combate |
+| Los cadáveres no desaparecen | Configurar `Rate.Corpse.Decay.Looted = 0.01` en `worldserver.conf` |
+
+---
+
+## Limitaciones conocidas
+
+- Las preferencias de activación/desactivación (`.aoeloot on/off`) no persisten entre sesiones.
+- El saqueo AOE se activa solo cuando un jugador saquea un cadáver; los jugadores inactivos cerca de un combate no recolectan automáticamente.
+
+---
+
+## Créditos
+
+- **acidmanifesto** — [Autor original y concepto](https://github.com/azerothcore/mod-aoe-loot/pull/2)
+- **Comunidad AzerothCore** — Hooks, actualizaciones y mejoras
+- **Colaboradores** — Comandos de jugador, soporte multi-idioma y corrección de errores
+
+## Enlaces
+
+- **AzerothCore:** [Repositorio](https://github.com/azerothcore) | [Sitio web](https://azerothcore.org/) | [Discord](https://discord.gg/PaqQRkd)
+- **Repositorio del módulo:** [GitHub](https://github.com/azerothcore/mod-aoe-loot)
+- **Problemas y sugerencias:** [Issue Tracker](https://github.com/azerothcore/mod-aoe-loot/issues)
+
+## Licencia
+
+Este módulo se distribuye bajo la [Licencia GNU AGPL v3](https://github.com/azerothcore/mod-aoe-loot/blob/master/LICENSE).

--- a/conf/mod_aoe_loot.conf.dist
+++ b/conf/mod_aoe_loot.conf.dist
@@ -5,20 +5,18 @@
 # unlimited permission to copy and/or distribute it, with or without
 # modifications, as long as this notice is preserved.
 #
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-#
-# User has manually chosen to ignore the git-tests, so throw them a warning.
-# This is done EACH compile so they can be alerted about the consequences.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY, to the extent permitted by law; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
 ########################################
 # AoeLoot module configuration
 ########################################
+
 #
 #    AOELoot.Enable
-#        Description: Enables Module
+#        Description: Enable or disable the AOE Loot module globally.
 #        Default:     1 - (Enabled)
 #                     0 - (Disabled)
 #
@@ -27,7 +25,7 @@ AOELoot.Enable = 1
 
 #
 #    AOELoot.Message
-#        Description: Enables area loot if the player is in a group
+#        Description: Show an informational message to players on login.
 #        Default:     1 - (Enabled)
 #                     0 - (Disabled)
 #
@@ -36,18 +34,43 @@ AOELoot.Message = 1
 
 #
 #    AOELoot.Range
-#       Description: Maximum reach range search loot.
-#       Default:    55.0
-#       Range:      5.0 - 100.0
+#        Description: Maximum distance in yards to search for nearby lootable corpses.
+#        Default:     55.0
+#        Range:       5.0 - 100.0
 #
 
 AOELoot.Range = 55.0
 
 #
 #    AOELoot.Group
-#        Description: Enables area loot if the player is in a group
+#        Description: Enable AOE looting when the player is in a group.
+#
+#        GROUP LOOT BEHAVIOR (important for administrators and players):
+#        When this option is enabled and the group loot method is Group Loot,
+#        Round Robin, or Need Before Greed, the module respects the server's
+#        round-robin rotation. Each player auto-collects loot from the corpses
+#        assigned to them by the rotation — items land directly in their bags
+#        without requiring them to click on each individual corpse.
+#
+#        If a player opens a corpse that belongs to another group member's
+#        round-robin slot, that member's items are immediately and automatically
+#        sent to their bags. The opener receives no items from that corpse.
+#
+#        Free For All and Master Loot groups are not affected by these
+#        restrictions: any group member receives loot from all nearby corpses.
+#
 #        Default:     1 - (Enabled)
 #                     0 - (Disabled)
 #
 
 AOELoot.Group = 1
+
+#
+#    AOELoot.MaxCorpses
+#        Description: Maximum number of nearby corpses processed per loot trigger.
+#                     Increase for larger pulls, decrease for lower server load.
+#        Default:     20
+#        Range:       1 - 50
+#
+
+AOELoot.MaxCorpses = 20

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -47,6 +47,31 @@ void AOELootPlayer::OnPlayerCreatureLootOpened(Player* player, Creature* mainCre
     if (player->GetGroup() && !sConfigMgr->GetOption<bool>("AOELoot.Group", true))
         return;
 
+    // If this player opened a corpse whose round-robin slot belongs to another
+    // group member, immediately auto-take for the rightful owner. The hook fires
+    // after SMSG_LOOT_RESPONSE is sent, so the opener already sees the items in
+    // their client window — but all item takes are validated server-side. By
+    // consuming the items for the owner first (synchronously, before any
+    // CMSG_AUTOSTORE_LOOT_ITEM can arrive), the opener's subsequent take
+    // attempts will find the slots already marked is_looted and be rejected.
+    if (Group* group = player->GetGroup())
+    {
+        if (mainCreature->GetLootRecipientGroup() == group)
+        {
+            LootMethod const method = group->GetLootMethod();
+            if (method == GROUP_LOOT || method == ROUND_ROBIN || method == NEED_BEFORE_GREED)
+            {
+                ObjectGuid const rrGuid = mainCreature->loot.roundRobinPlayer;
+                if (rrGuid && rrGuid != player->GetGUID())
+                {
+                    if (Player* owner = ObjectAccessor::FindConnectedPlayer(rrGuid))
+                        if (owner->GetMap() == mainCreature->GetMap())
+                            owner->AutoTakeCreatureLoot(mainCreature);
+                }
+            }
+        }
+    }
+
     float range = sConfigMgr->GetOption<float>("AOELoot.Range", 55.0f);
     if (range < 5.0f)   range = 5.0f;
     if (range > 100.0f) range = 100.0f;

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -98,22 +98,25 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
             if (!player->isAllowedToLoot(c))
                 return true;
 
-            // For loot methods that assign per-corpse ownership (GROUP_LOOT, ROUND_ROBIN,
-            // NEED_BEFORE_GREED), only merge corpses where this player is the tap
-            // recipient. Corpses tapped by other group members are left for them to loot
-            // directly; they must not be consumed by a different player's AOE pass.
+            // GROUP_LOOT, ROUND_ROBIN, and NEED_BEFORE_GREED distribute items through
+            // the round-robin system: roundRobinPlayer (set lazily on the first SendLoot
+            // call) determines which group member receives under-threshold items from a
+            // given corpse. GetLootRecipient() reflects who tapped the creature, not who
+            // the round-robin assigns — if one player consistently attacks first, they
+            // would be the tap recipient for every nearby corpse, and the merge would
+            // give them all items while other group members receive nothing.
             //
-            // NOTE: roundRobinPlayer is set lazily (on first SendLoot call), so it is
-            // empty for unopened corpses and cannot be used to determine ownership here.
-            // GetLootRecipient() reflects the player who held the tap at creature death
-            // and is the correct ownership signal at this stage.
+            // To preserve fair distribution, group-tagged corpses are excluded from the
+            // merge entirely for these loot methods. Each player opens each corpse
+            // individually and the server's round-robin system assigns items correctly.
+            // AOE merge continues to work for FREE_FOR_ALL, MASTER_LOOT, and solo kills.
             if (Group* group = player->GetGroup())
             {
                 if (c->GetLootRecipientGroup() == group)
                 {
                     LootMethod const method = group->GetLootMethod();
                     if (method == ROUND_ROBIN || method == GROUP_LOOT || method == NEED_BEFORE_GREED)
-                        return c->GetLootRecipient() != player;
+                        return true;
                 }
             }
 
@@ -130,15 +133,17 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
     // Determines whether the current player is eligible to take a specific item
     // from a source creature's loot.
     //
-    // Corpse-level ownership (GROUP_LOOT / ROUND_ROBIN / NEED_BEFORE_GREED) is
-    // already enforced by the nearbyCorpses filter above using GetLootRecipient().
-    // This lambda handles only per-item checks that apply after that filter:
-    //   - is_blocked  : active roll in flight — never touch.
+    // By the time this lambda runs, the nearbyCorpses filter has already removed
+    // all group-tagged corpses for GROUP_LOOT / ROUND_ROBIN / NEED_BEFORE_GREED,
+    // so the only corpses that reach here are:
+    //   - Solo kills (no loot recipient group)
+    //   - Group kills in FREE_FOR_ALL or MASTER_LOOT mode
+    //
+    // Per-item checks still needed:
+    //   - is_blocked  : active Need/Greed roll in flight — never touch.
     //   - freeforall  : personal drop, any eligible player may take a copy.
     //   - allowedGUIDs: post-roll assignment to specific players.
-    //   - standard    : for solo kills verify direct ownership;
-    //                   for group kills the filter already guarantees the player
-    //                   is the correct recipient, so membership check is enough.
+    //   - standard    : verify solo tap ownership or group membership.
     auto isEligibleForPlayer = [&](LootItem const& item, Creature* src) -> bool
     {
         // Never touch items with an active Need/Greed roll. The roll system owns
@@ -156,9 +161,8 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
         if (!item.allowedGUIDs.empty())
             return item.allowedGUIDs.count(player->GetGUID()) > 0;
 
-        // Standard items: solo kill must match the tap recipient directly;
-        // group kill corpses that reach here have already been filtered to this
-        // player's tap, so group membership is sufficient.
+        // Standard items: verify tap ownership for solo kills, or group membership
+        // for FREE_FOR_ALL / MASTER_LOOT group kills
         Group* recipientGroup = src->GetLootRecipientGroup();
         if (!recipientGroup)
             return src->GetLootRecipient() == player;

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -16,8 +16,6 @@
  */
 
 #include "aoe_loot.h"
-#include "ObjectMgr.h"
-#include <algorithm>
 #include <limits>
 
 std::map<uint64, bool> AoeLootCommandScript::playerAoeLootEnabled;
@@ -180,7 +178,6 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
 
     // Collect items to merge (don't modify main loot directly yet)
     std::vector<LootItem> itemsToAdd;
-    std::vector<LootItem> questItemsToAdd;
 
     for (Creature* creature : nearbyCorpses)
     {
@@ -221,8 +218,7 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
                 continue;
             }
 
-            if ((mainLoot->items.size() + itemsToAdd.size() +
-                 mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
+            if (mainLoot->items.size() + itemsToAdd.size() >= MAX_LOOT_ITEMS)
                 break;
 
             itemsToAdd.push_back(srcItem);
@@ -231,66 +227,6 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
             srcItem.is_looted = true;
             if (loot->unlootedCount > 0)
                 --loot->unlootedCount;
-        }
-
-        // Collect quest items (per-player, capped to how many the player still needs)
-        for (size_t i = 0; i < loot->quest_items.size(); ++i)
-        {
-            if ((mainLoot->items.size() + itemsToAdd.size() +
-                 mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
-                break;
-
-            LootItem const& questItem = loot->quest_items[i];
-
-            if (questItem.is_looted)
-                continue;
-
-            // Skip items the player doesn't need for any active quest
-            if (!player->HasQuestForItem(questItem.itemid))
-                continue;
-
-            // Calculate how many the player still needs across all active quests
-            uint32 maxNeeded = 0;
-            for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
-            {
-                uint32 questId = player->GetQuestSlotQuestId(slot);
-                if (!questId)
-                    continue;
-
-                Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-                if (!quest)
-                    continue;
-
-                for (uint8 j = 0; j < QUEST_ITEM_OBJECTIVES_COUNT; ++j)
-                {
-                    if (quest->RequiredItemId[j] == questItem.itemid && quest->RequiredItemCount[j] > maxNeeded)
-                        maxNeeded = quest->RequiredItemCount[j];
-                }
-            }
-
-            if (maxNeeded == 0)
-                continue;
-
-            // Count how many the player already has, plus items pending delivery
-            uint32 ownedCount = player->GetItemCount(questItem.itemid, true);
-            for (auto const& pending : questItemsToAdd)
-            {
-                if (pending.itemid == questItem.itemid)
-                    ownedCount += pending.count;
-            }
-            for (auto const& mainQuestItem : mainLoot->quest_items)
-            {
-                if (mainQuestItem.itemid == questItem.itemid)
-                    ownedCount += mainQuestItem.count;
-            }
-
-            if (ownedCount >= maxNeeded)
-                continue;
-
-            uint32 stillNeeded = maxNeeded - ownedCount;
-            LootItem cappedItem = questItem;
-            cappedItem.count = std::min(static_cast<uint32>(questItem.count), stillNeeded);
-            questItemsToAdd.push_back(cappedItem);
         }
 
         // Only remove the lootable flag when there is truly nothing left for anyone.
@@ -313,15 +249,6 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
     {
         if (mainLoot->items.size() < MAX_LOOT_ITEMS)
             mainLoot->items.push_back(item);
-    }
-
-    // Deliver quest items directly to player inventory
-    for (LootItem const& item : questItemsToAdd)
-    {
-        if (!player->HasQuestForItem(item.itemid))
-            continue;
-
-        player->AddItem(item.itemid, item.count);
     }
 
     // Send merged loot window

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -119,6 +119,13 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
     // corpse so other group members can still loot them.
     auto isEligibleForPlayer = [&](Loot const* loot, LootItem const& item, Creature* src) -> bool
     {
+        // Never touch items with an active Need/Greed roll. The roll system owns
+        // these until it resolves and populates allowedGUIDs with the winner.
+        // Merging a blocked item would mark it as looted in the source while the
+        // roll is still in flight, making it disappear for everyone.
+        if (item.is_blocked)
+            return false;
+
         // FFA items: any eligible player may take their own copy
         if (item.freeforall)
             return true;

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "aoe_loot.h"
-#include <limits>
 
 std::map<uint64, bool> AoeLootCommandScript::playerAoeLootEnabled;
 
@@ -30,242 +29,68 @@ void AOELootPlayer::OnPlayerLogin(Player* player)
             ChatHandler(session).PSendModuleSysMessage(MODULE_STRING, AOE_LOGIN_MESSAGE);
 }
 
-bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& packet)
+void AOELootPlayer::OnPlayerCreatureLootOpened(Player* player, Creature* mainCreature)
 {
-    // Only handle loot packets
-    if (packet.GetOpcode() != CMSG_LOOT)
-        return true;
+    if (!player || !mainCreature)
+        return;
 
-    // Basic validation checks
-    if (!session)
-        return true;
-
-    Player* player = session->GetPlayer();
-    if (!player)
-        return true;
-
-    // Check if module is enabled
     if (!sConfigMgr->GetOption<bool>("AOELoot.Enable", true))
-        return true;
+        return;
 
-    // Check if player has AOE loot disabled via command
-    uint64 playerGuid = player->GetGUID().GetRawValue();
+    // Per-player toggle
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
     if (AoeLootCommandScript::hasPlayerAoeLootEnabled(playerGuid) &&
         !AoeLootCommandScript::getPlayerAoeLootEnabled(playerGuid))
-        return true;
+        return;
 
-    // Check group settings
+    // Respect group config option
     if (player->GetGroup() && !sConfigMgr->GetOption<bool>("AOELoot.Group", true))
-        return true;
+        return;
 
-    // Get configured loot range
     float range = sConfigMgr->GetOption<float>("AOELoot.Range", 55.0f);
+    if (range < 5.0f)   range = 5.0f;
+    if (range > 100.0f) range = 100.0f;
 
-    // Limit range to reasonable values
-    if (range < 5.0f)
-        range = 5.0f;
+    size_t const maxCorpses = static_cast<size_t>(sConfigMgr->GetOption<uint32>("AOELoot.MaxCorpses", 20));
 
-    if (range > 100.0f)
-        range = 100.0f;
-
-    // Read target GUID from packet
-    WorldPacket packetCopy(packet);
-    ObjectGuid targetGuid;
-    packetCopy >> targetGuid;
-
-    if (!targetGuid)
-        return true;
-
-    // Get target creature
-    Creature* mainCreature = player->GetMap()->GetCreature(targetGuid);
-    if (!mainCreature)
-        return true;
-
-    // Check if main creature has loot
-    if (!mainCreature->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
-        return true;
-
-    // Get nearby corpses
     std::list<Creature*> nearbyCorpses;
     player->GetDeadCreatureListInGrid(nearbyCorpses, range);
 
-    // Remove invalid corpses and main target
     nearbyCorpses.remove_if([&](Creature* c)
-        {
-            if (!c || c->GetGUID() == targetGuid || !c->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
-                return true;
-
-            if (!player->isAllowedToLoot(c))
-                return true;
-
-            // GROUP_LOOT, ROUND_ROBIN, and NEED_BEFORE_GREED distribute items through
-            // the round-robin system: roundRobinPlayer (set lazily on the first SendLoot
-            // call) determines which group member receives under-threshold items from a
-            // given corpse. GetLootRecipient() reflects who tapped the creature, not who
-            // the round-robin assigns — if one player consistently attacks first, they
-            // would be the tap recipient for every nearby corpse, and the merge would
-            // give them all items while other group members receive nothing.
-            //
-            // To preserve fair distribution, group-tagged corpses are excluded from the
-            // merge entirely for these loot methods. Each player opens each corpse
-            // individually and the server's round-robin system assigns items correctly.
-            // AOE merge continues to work for FREE_FOR_ALL, MASTER_LOOT, and solo kills.
-            if (Group* group = player->GetGroup())
-            {
-                if (c->GetLootRecipientGroup() == group)
-                {
-                    LootMethod const method = group->GetLootMethod();
-                    if (method == ROUND_ROBIN || method == GROUP_LOOT || method == NEED_BEFORE_GREED)
-                        return true;
-                }
-            }
-
-            return false;
-        });
-
-    // If no other corpses, process normally
-    if (nearbyCorpses.empty())
     {
-        player->SendLoot(targetGuid, LOOT_CORPSE);
-        return false;
-    }
-
-    // Determines whether the current player is eligible to take a specific item
-    // from a source creature's loot.
-    //
-    // By the time this lambda runs, the nearbyCorpses filter has already removed
-    // all group-tagged corpses for GROUP_LOOT / ROUND_ROBIN / NEED_BEFORE_GREED,
-    // so the only corpses that reach here are:
-    //   - Solo kills (no loot recipient group)
-    //   - Group kills in FREE_FOR_ALL or MASTER_LOOT mode
-    //
-    // Per-item checks still needed:
-    //   - is_blocked  : active Need/Greed roll in flight — never touch.
-    //   - freeforall  : personal drop, any eligible player may take a copy.
-    //   - allowedGUIDs: post-roll assignment to specific players.
-    //   - standard    : verify solo tap ownership or group membership.
-    auto isEligibleForPlayer = [&](LootItem const& item, Creature* src) -> bool
-    {
-        // Never touch items with an active Need/Greed roll. The roll system owns
-        // these until it resolves and populates allowedGUIDs with the winner.
-        // Merging a blocked item would mark it as looted in the source while the
-        // roll is still in flight, making it disappear for everyone.
-        if (item.is_blocked)
-            return false;
-
-        // FFA items: any eligible player may take their own copy
-        if (item.freeforall)
+        if (!c || c->GetGUID() == mainCreature->GetGUID())
             return true;
 
-        // Items assigned to specific players (e.g., after a Need/Greed roll result)
-        if (!item.allowedGUIDs.empty())
-            return item.allowedGUIDs.count(player->GetGUID()) > 0;
+        if (!c->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
+            return true;
 
-        // Standard items: verify tap ownership for solo kills, or group membership
-        // for FREE_FOR_ALL / MASTER_LOOT group kills
-        Group* recipientGroup = src->GetLootRecipientGroup();
-        if (!recipientGroup)
-            return src->GetLootRecipient() == player;
+        // isAllowedToLoot covers all ownership and group-loot-method rules:
+        // it checks roundRobinPlayer (set at creature death), allowedGUIDs
+        // (post-roll assignment), group membership, and loot type. Any
+        // corpse that passes this check has items the player is entitled
+        // to take under the server's own loot rules.
+        if (!player->isAllowedToLoot(c))
+            return true;
 
-        return recipientGroup == player->GetGroup();
-    };
+        return false;
+    });
 
-    // Get main loot
-    Loot* mainLoot = &mainCreature->loot;
-
-    // Use configured max corpses value
-    size_t const maxCorpses = static_cast<size_t>(sConfigMgr->GetOption<uint32>("AOELoot.MaxCorpses", 20));
-    size_t processedCorpses = 0;
-
-    // Track total gold to merge
-    uint32 totalGold = mainLoot->gold;
-
-    // Collect items to merge (don't modify main loot directly yet)
-    std::vector<LootItem> itemsToAdd;
-
-    for (Creature* creature : nearbyCorpses)
+    size_t processed = 0;
+    for (Creature* corpse : nearbyCorpses)
     {
-        if (processedCorpses >= maxCorpses)
+        if (processed >= maxCorpses)
             break;
 
-        if (!creature)
-            continue;
-
-        Loot* loot = &creature->loot;
-
-        // Skip already looted corpses
-        if (loot->isLooted())
-            continue;
-
-        // Merge gold. In group loot, gold is taken by whoever opens the corpse
-        // first, consistent with vanilla round-robin behavior.
-        if (loot->gold > 0)
-        {
-            if (totalGold < (std::numeric_limits<uint32>::max() - loot->gold))
-                totalGold += loot->gold;
-            loot->gold = 0;
-        }
-
-        // Surgically collect only the items this player is eligible for.
-        // Items that belong to other group members (different round-robin slot,
-        // specific allowedGUIDs, etc.) are skipped so the corpse remains
-        // lootable for the rightful owner.
-        bool itemsRemainingForOthers = false;
-        for (auto& srcItem : loot->items)
-        {
-            if (srcItem.is_looted)
-                continue;
-
-            if (!isEligibleForPlayer(srcItem, creature))
-            {
-                itemsRemainingForOthers = true;
-                continue;
-            }
-
-            if (mainLoot->items.size() + itemsToAdd.size() >= MAX_LOOT_ITEMS)
-                break;
-
-            itemsToAdd.push_back(srcItem);
-
-            // Mark item as taken in the source so the loot state stays consistent
-            srcItem.is_looted = true;
-            if (loot->unlootedCount > 0)
-                --loot->unlootedCount;
-        }
-
-        // Only remove the lootable flag when there is truly nothing left for anyone.
-        // If other group members still have eligible items, the corpse must remain
-        // lootable so they can claim what belongs to them.
-        if (!itemsRemainingForOthers && loot->isLooted())
-        {
-            creature->AllLootRemovedFromCorpse();
-            creature->RemoveDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
-        }
-
-        processedCorpses++;
+        if (player->AutoTakeCreatureLoot(corpse))
+            ++processed;
     }
-
-    // Apply merged gold to the main loot window
-    mainLoot->gold = totalGold;
-
-    // Add eligible regular items to the main loot window
-    for (LootItem const& item : itemsToAdd)
-    {
-        if (mainLoot->items.size() < MAX_LOOT_ITEMS)
-            mainLoot->items.push_back(item);
-    }
-
-    // Send merged loot window
-    player->SendLoot(targetGuid, LOOT_CORPSE);
-
-    return false;
 }
 
 ChatCommandTable AoeLootCommandScript::GetCommands() const
 {
     static ChatCommandTable aoeLootSubCommandTable =
     {
-        { "on", HandleAoeLootOnCommand, SEC_PLAYER, Console::No },
+        { "on",  HandleAoeLootOnCommand,  SEC_PLAYER, Console::No },
         { "off", HandleAoeLootOffCommand, SEC_PLAYER, Console::No }
     };
 
@@ -301,7 +126,7 @@ bool AoeLootCommandScript::HandleAoeLootOnCommand(ChatHandler* handler, Optional
     if (!player)
         return true;
 
-    uint64 playerGuid = player->GetGUID().GetRawValue();
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
 
     if (AoeLootCommandScript::hasPlayerAoeLootEnabled(playerGuid) &&
         AoeLootCommandScript::getPlayerAoeLootEnabled(playerGuid))
@@ -321,7 +146,7 @@ bool AoeLootCommandScript::HandleAoeLootOffCommand(ChatHandler* handler, Optiona
     if (!player)
         return true;
 
-    uint64 playerGuid = player->GetGUID().GetRawValue();
+    uint64 const playerGuid = player->GetGUID().GetRawValue();
 
     if (AoeLootCommandScript::hasPlayerAoeLootEnabled(playerGuid) &&
         !AoeLootCommandScript::getPlayerAoeLootEnabled(playerGuid))

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -94,10 +94,32 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
     // Remove invalid corpses and main target
     nearbyCorpses.remove_if([&](Creature* c)
         {
-            return !c ||
-                c->GetGUID() == targetGuid ||
-                !c->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE) ||
-                !player->isAllowedToLoot(c);
+            if (!c || c->GetGUID() == targetGuid || !c->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
+                return true;
+
+            if (!player->isAllowedToLoot(c))
+                return true;
+
+            // For loot methods that assign per-corpse ownership (GROUP_LOOT, ROUND_ROBIN,
+            // NEED_BEFORE_GREED), only merge corpses where this player is the tap
+            // recipient. Corpses tapped by other group members are left for them to loot
+            // directly; they must not be consumed by a different player's AOE pass.
+            //
+            // NOTE: roundRobinPlayer is set lazily (on first SendLoot call), so it is
+            // empty for unopened corpses and cannot be used to determine ownership here.
+            // GetLootRecipient() reflects the player who held the tap at creature death
+            // and is the correct ownership signal at this stage.
+            if (Group* group = player->GetGroup())
+            {
+                if (c->GetLootRecipientGroup() == group)
+                {
+                    LootMethod const method = group->GetLootMethod();
+                    if (method == ROUND_ROBIN || method == GROUP_LOOT || method == NEED_BEFORE_GREED)
+                        return c->GetLootRecipient() != player;
+                }
+            }
+
+            return false;
         });
 
     // If no other corpses, process normally
@@ -108,16 +130,18 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
     }
 
     // Determines whether the current player is eligible to take a specific item
-    // from a source creature's loot, respecting group loot rules and item ownership.
+    // from a source creature's loot.
     //
-    // In a group context, items are owned by:
-    //   - A specific set of players after a Need/Greed roll  (allowedGUIDs)
-    //   - The round-robin player for under-threshold items   (roundRobinPlayer)
-    //   - Any player in the group for FFA / Master Loot
-    //
-    // Items not eligible for the current player are left untouched on the source
-    // corpse so other group members can still loot them.
-    auto isEligibleForPlayer = [&](Loot const* loot, LootItem const& item, Creature* src) -> bool
+    // Corpse-level ownership (GROUP_LOOT / ROUND_ROBIN / NEED_BEFORE_GREED) is
+    // already enforced by the nearbyCorpses filter above using GetLootRecipient().
+    // This lambda handles only per-item checks that apply after that filter:
+    //   - is_blocked  : active roll in flight — never touch.
+    //   - freeforall  : personal drop, any eligible player may take a copy.
+    //   - allowedGUIDs: post-roll assignment to specific players.
+    //   - standard    : for solo kills verify direct ownership;
+    //                   for group kills the filter already guarantees the player
+    //                   is the correct recipient, so membership check is enough.
+    auto isEligibleForPlayer = [&](LootItem const& item, Creature* src) -> bool
     {
         // Never touch items with an active Need/Greed roll. The roll system owns
         // these until it resolves and populates allowedGUIDs with the winner.
@@ -134,29 +158,14 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
         if (!item.allowedGUIDs.empty())
             return item.allowedGUIDs.count(player->GetGUID()) > 0;
 
-        // Round-robin / standard items: verify group loot ownership
+        // Standard items: solo kill must match the tap recipient directly;
+        // group kill corpses that reach here have already been filtered to this
+        // player's tap, so group membership is sufficient.
         Group* recipientGroup = src->GetLootRecipientGroup();
         if (!recipientGroup)
             return src->GetLootRecipient() == player;
 
-        if (recipientGroup != player->GetGroup())
-            return false;
-
-        switch (recipientGroup->GetLootMethod())
-        {
-            case FREE_FOR_ALL:
-            case MASTER_LOOT:
-                return true;
-            case ROUND_ROBIN:
-            case GROUP_LOOT:
-            case NEED_BEFORE_GREED:
-                // Under-threshold items go to the round-robin player.
-                // If roundRobinPlayer is empty the slot has been released and
-                // any group member may take the item.
-                return !loot->roundRobinPlayer || loot->roundRobinPlayer == player->GetGUID();
-            default:
-                return false;
-        }
+        return recipientGroup == player->GetGroup();
     };
 
     // Get main loot
@@ -206,7 +215,7 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
             if (srcItem.is_looted)
                 continue;
 
-            if (!isEligibleForPlayer(loot, srcItem, creature))
+            if (!isEligibleForPlayer(srcItem, creature))
             {
                 itemsRemainingForOthers = true;
                 continue;

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -19,6 +19,50 @@
 
 std::map<uint64, bool> AoeLootCommandScript::playerAoeLootEnabled;
 
+bool AutoTakeCreatureLoot(Player* player, Creature* creature)
+{
+    if (!creature || !creature->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
+        return false;
+
+    if (!player->isAllowedToLoot(creature))
+        return false;
+
+    Loot* loot = &creature->loot;
+
+    // Ensure per-player item tracking is initialised (no-op if already done
+    // for this player at creature death via Loot::FillLoot).
+    loot->FillNotNormalLootFor(player);
+
+    // Temporarily redirect the player's active loot GUID so StoreLootItem
+    // internal checks operate against this creature.
+    ObjectGuid savedLootGuid = player->GetLootGUID();
+    player->SetLootGUID(creature->GetGUID());
+    loot->AddLooter(player->GetGUID());
+
+    bool tookAnything = false;
+    uint32 const maxSlots = loot->GetMaxSlotInLootFor(player);
+    for (uint32 slot = 0; slot < maxSlots; ++slot)
+    {
+        if (slot > std::numeric_limits<uint8>::max())
+            break;
+
+        InventoryResult msg;
+        if (player->StoreLootItem(static_cast<uint8>(slot), loot, msg))
+            tookAnything = true;
+    }
+
+    loot->RemoveLooter(player->GetGUID());
+    player->SetLootGUID(savedLootGuid);
+
+    if (loot->isLooted())
+    {
+        creature->AllLootRemovedFromCorpse();
+        creature->RemoveDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
+    }
+
+    return tookAnything;
+}
+
 void AOELootPlayer::OnPlayerLogin(Player* player)
 {
     if (!player)
@@ -66,7 +110,7 @@ void AOELootPlayer::OnPlayerCreatureLootOpened(Player* player, Creature* mainCre
                 {
                     if (Player* owner = ObjectAccessor::FindConnectedPlayer(rrGuid))
                         if (owner->GetMap() == mainCreature->GetMap())
-                            owner->AutoTakeCreatureLoot(mainCreature);
+                            AutoTakeCreatureLoot(owner, mainCreature);
                 }
             }
         }
@@ -128,7 +172,7 @@ void AOELootPlayer::OnPlayerCreatureLootOpened(Player* player, Creature* mainCre
         if (processed >= maxCorpses)
             break;
 
-        if (player->AutoTakeCreatureLoot(corpse))
+        if (AutoTakeCreatureLoot(player, corpse))
             ++processed;
     }
 }

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -107,17 +107,62 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
         return false;
     }
 
+    // Determines whether the current player is eligible to take a specific item
+    // from a source creature's loot, respecting group loot rules and item ownership.
+    //
+    // In a group context, items are owned by:
+    //   - A specific set of players after a Need/Greed roll  (allowedGUIDs)
+    //   - The round-robin player for under-threshold items   (roundRobinPlayer)
+    //   - Any player in the group for FFA / Master Loot
+    //
+    // Items not eligible for the current player are left untouched on the source
+    // corpse so other group members can still loot them.
+    auto isEligibleForPlayer = [&](Loot const* loot, LootItem const& item, Creature* src) -> bool
+    {
+        // FFA items: any eligible player may take their own copy
+        if (item.freeforall)
+            return true;
+
+        // Items assigned to specific players (e.g., after a Need/Greed roll result)
+        if (!item.allowedGUIDs.empty())
+            return item.allowedGUIDs.count(player->GetGUID()) > 0;
+
+        // Round-robin / standard items: verify group loot ownership
+        Group* recipientGroup = src->GetLootRecipientGroup();
+        if (!recipientGroup)
+            return src->GetLootRecipient() == player;
+
+        if (recipientGroup != player->GetGroup())
+            return false;
+
+        switch (recipientGroup->GetLootMethod())
+        {
+            case FREE_FOR_ALL:
+            case MASTER_LOOT:
+                return true;
+            case ROUND_ROBIN:
+            case GROUP_LOOT:
+            case NEED_BEFORE_GREED:
+                // Under-threshold items go to the round-robin player.
+                // If roundRobinPlayer is empty the slot has been released and
+                // any group member may take the item.
+                return !loot->roundRobinPlayer || loot->roundRobinPlayer == player->GetGUID();
+            default:
+                return false;
+        }
+    };
+
     // Get main loot
     Loot* mainLoot = &mainCreature->loot;
 
-    // Limit number of corpses to process
-    size_t const maxCorpses = 10; // set to 10 to improve stability
+    // Use configured max corpses value
+    size_t const maxCorpses = static_cast<size_t>(sConfigMgr->GetOption<uint32>("AOELoot.MaxCorpses", 20));
     size_t processedCorpses = 0;
 
     // Track total gold to merge
     uint32 totalGold = mainLoot->gold;
 
-    // Collect all items to merge (don't modify main loot directly)
+    // Collect items to merge (don't modify main loot directly yet)
     std::vector<LootItem> itemsToAdd;
     std::vector<LootItem> questItemsToAdd;
 
@@ -135,32 +180,54 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
         if (loot->isLooted())
             continue;
 
-        // Collect gold
+        // Merge gold. In group loot, gold is taken by whoever opens the corpse
+        // first, consistent with vanilla round-robin behavior.
         if (loot->gold > 0)
         {
-            // Prevent overflow
             if (totalGold < (std::numeric_limits<uint32>::max() - loot->gold))
                 totalGold += loot->gold;
+            loot->gold = 0;
         }
 
-        // Collect regular items
-        for (size_t i = 0; i < loot->items.size(); ++i)
+        // Surgically collect only the items this player is eligible for.
+        // Items that belong to other group members (different round-robin slot,
+        // specific allowedGUIDs, etc.) are skipped so the corpse remains
+        // lootable for the rightful owner.
+        bool itemsRemainingForOthers = false;
+        for (auto& srcItem : loot->items)
         {
-            // Check if there's still space
-            if ((mainLoot->items.size() + itemsToAdd.size() + mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
+            if (srcItem.is_looted)
+                continue;
+
+            if (!isEligibleForPlayer(loot, srcItem, creature))
+            {
+                itemsRemainingForOthers = true;
+                continue;
+            }
+
+            if ((mainLoot->items.size() + itemsToAdd.size() +
+                 mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
                 break;
 
-            itemsToAdd.push_back(loot->items[i]);
+            itemsToAdd.push_back(srcItem);
+
+            // Mark item as taken in the source so the loot state stays consistent
+            srcItem.is_looted = true;
+            if (loot->unlootedCount > 0)
+                --loot->unlootedCount;
         }
 
-        // Collect quest items (only for active quests, limited to needed count)
+        // Collect quest items (per-player, capped to how many the player still needs)
         for (size_t i = 0; i < loot->quest_items.size(); ++i)
         {
-            // Check if there's still space
-            if ((mainLoot->items.size() + itemsToAdd.size() + mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
+            if ((mainLoot->items.size() + itemsToAdd.size() +
+                 mainLoot->quest_items.size() + questItemsToAdd.size()) >= MAX_LOOT_ITEMS)
                 break;
 
             LootItem const& questItem = loot->quest_items[i];
+
+            if (questItem.is_looted)
+                continue;
 
             // Skip items the player doesn't need for any active quest
             if (!player->HasQuestForItem(questItem.itemid))
@@ -188,8 +255,7 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
             if (maxNeeded == 0)
                 continue;
 
-            // Count how many the player already has, plus pending adds
-            // and quest items already in the main loot window
+            // Count how many the player already has, plus items pending delivery
             uint32 ownedCount = player->GetItemCount(questItem.itemid, true);
             for (auto const& pending : questItemsToAdd)
             {
@@ -208,31 +274,33 @@ bool AOELootServer::CanPacketReceive(WorldSession* session, WorldPacket const& p
             uint32 stillNeeded = maxNeeded - ownedCount;
             LootItem cappedItem = questItem;
             cappedItem.count = std::min(static_cast<uint32>(questItem.count), stillNeeded);
-
             questItemsToAdd.push_back(cappedItem);
         }
 
-        // Clear source loot (but don't modify vector directly)
-        loot->clear();
-        creature->AllLootRemovedFromCorpse();
-        creature->RemoveDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
+        // Only remove the lootable flag when there is truly nothing left for anyone.
+        // If other group members still have eligible items, the corpse must remain
+        // lootable so they can claim what belongs to them.
+        if (!itemsRemainingForOthers && loot->isLooted())
+        {
+            creature->AllLootRemovedFromCorpse();
+            creature->RemoveDynamicFlag(UNIT_DYNFLAG_LOOTABLE);
+        }
 
         processedCorpses++;
     }
 
-    // Now safely add collected items to main loot
-    // Update gold
+    // Apply merged gold to the main loot window
     mainLoot->gold = totalGold;
 
-    // Add regular items
-    for (const auto& item : itemsToAdd)
+    // Add eligible regular items to the main loot window
+    for (LootItem const& item : itemsToAdd)
     {
         if (mainLoot->items.size() < MAX_LOOT_ITEMS)
             mainLoot->items.push_back(item);
     }
 
-    // Add quest items directly to player inventory
-    for (const auto& item : questItemsToAdd)
+    // Deliver quest items directly to player inventory
+    for (LootItem const& item : questItemsToAdd)
     {
         if (!player->HasQuestForItem(item.itemid))
             continue;

--- a/src/aoe_loot.cpp
+++ b/src/aoe_loot.cpp
@@ -64,13 +64,35 @@ void AOELootPlayer::OnPlayerCreatureLootOpened(Player* player, Creature* mainCre
         if (!c->HasDynamicFlag(UNIT_DYNFLAG_LOOTABLE))
             return true;
 
-        // isAllowedToLoot covers all ownership and group-loot-method rules:
-        // it checks roundRobinPlayer (set at creature death), allowedGUIDs
-        // (post-roll assignment), group membership, and loot type. Any
-        // corpse that passes this check has items the player is entitled
-        // to take under the server's own loot rules.
+        // isAllowedToLoot checks group membership and whether the player has
+        // at least one item available (including quest items). It is a
+        // necessary but not sufficient condition for auto-take: it returns
+        // true for a player who has quest items on another player's
+        // round-robin corpse, which would cause AutoTakeCreatureLoot to
+        // take regular grey items that belong to the other player (because
+        // StoreLootItem does not block round-robin items in GROUP_LOOT mode
+        // — that protection is enforced client-side via LOOT_SLOT_TYPE_LOCKED).
         if (!player->isAllowedToLoot(c))
             return true;
+
+        // For group loot methods that distribute via round-robin, only
+        // auto-collect corpses where this player is the designated looter.
+        // roundRobinPlayer is set in Loot::FillLoot at creature death
+        // (Unit::Kill → Group::UpdateLooterGuid → SetLootRecipient →
+        // FillLoot:569) and correctly reflects the group's rotation.
+        if (Group* group = player->GetGroup())
+        {
+            if (c->GetLootRecipientGroup() == group)
+            {
+                LootMethod const method = group->GetLootMethod();
+                if (method == GROUP_LOOT || method == ROUND_ROBIN || method == NEED_BEFORE_GREED)
+                {
+                    ObjectGuid const rrPlayer = c->loot.roundRobinPlayer;
+                    if (rrPlayer && rrPlayer != player->GetGUID())
+                        return true;
+                }
+            }
+        }
 
         return false;
     });

--- a/src/aoe_loot.h
+++ b/src/aoe_loot.h
@@ -18,96 +18,42 @@
 #ifndef MODULE_AOELOOT_H
 #define MODULE_AOELOOT_H
 
-#include "ScriptMgr.h"
-#include "Config.h"
 #include "Chat.h"
-#include "Player.h"
-#include "ScriptedGossip.h"
-#include "Group.h"
-#include "LootMgr.h"
+#include "Config.h"
 #include "Creature.h"
-#include "Log.h"
-#include <vector>
+#include "Player.h"
+#include "ScriptMgr.h"
 #include <list>
-#include <algorithm>
+#include <map>
 #include <string>
 
 #define MODULE_STRING "mod-aoe-loot"
 
- // Maximum loot items count
-constexpr size_t MAX_LOOT_ITEMS = 16;
 using namespace Acore::ChatCommands;
 
 enum AoeLootString
 {
-    AOE_LOGIN_MESSAGE = 1,         // Login message
-    AOE_ITEM_IN_THE_MAIL = 2,      // Mail notification
-    AOE_MODULE_ACTIVE = 3,         // unused
-    AOE_QUEST_ITEM_SENT = 4,       // unused
-    AOE_LOOT_ALREADY_ENABLED = 5,  // Already enabled message
-    AOE_LOOT_ENABLED = 6,          // Enabled confirmation
-    AOE_LOOT_ALREADY_DISABLED = 7, // Already disabled message
-    AOE_LOOT_DISABLED = 8          // Disabled confirmation
+    AOE_LOGIN_MESSAGE        = 1,
+    AOE_ITEM_IN_THE_MAIL     = 2, // unused
+    AOE_MODULE_ACTIVE        = 3, // unused
+    AOE_QUEST_ITEM_SENT      = 4, // unused
+    AOE_LOOT_ALREADY_ENABLED = 5,
+    AOE_LOOT_ENABLED         = 6,
+    AOE_LOOT_ALREADY_DISABLED = 7,
+    AOE_LOOT_DISABLED        = 8
 };
 
 class AOELootPlayer : public PlayerScript
 {
 public:
-    AOELootPlayer() : PlayerScript("AOELootPlayer", { PLAYERHOOK_ON_LOGIN }) {}
+    AOELootPlayer() : PlayerScript("AOELootPlayer",
+        { PLAYERHOOK_ON_LOGIN, PLAYERHOOK_ON_CREATURE_LOOT_OPENED }) {}
 
     void OnPlayerLogin(Player* player) override;
-};
 
-class AOELootServer : public ServerScript
-{
-public:
-    AOELootServer() : ServerScript("AOELootServer", { SERVERHOOK_CAN_PACKET_RECEIVE }) {}
-
-    bool CanPacketReceive(WorldSession* session, WorldPacket const& packet) override;
-
-private:
-    // Helper function - Check if loot is valid
-    bool IsLootValid(Loot* loot) const;
-
-    // Check if loot can be merged
-    bool CanMergeLoot(Player* player, Creature* creature) const;
-
-    // Safely get item count
-    size_t GetSafeItemCount(Loot* loot) const;
-
-    // Safely merge loot items
-    bool SafeMergeLootItems(Loot* mainLoot, Loot* sourceLoot, size_t& remainingSlots);
-};
-
-// Configuration options structure (optional, for better config management)
-struct AOELootConfig
-{
-    bool enabled = true;
-    bool messageOnLogin = true;
-    bool allowInGroup = true;
-    float range = 55.0f;
-    uint32 maxCorpses = 20;
-
-    static AOELootConfig* instance()
-    {
-        static AOELootConfig instance;
-        return &instance;
-    }
-
-    void Load()
-    {
-        enabled = sConfigMgr->GetOption<bool>("AOELoot.Enable", true);
-        messageOnLogin = sConfigMgr->GetOption<bool>("AOELoot.Message", true);
-        allowInGroup = sConfigMgr->GetOption<bool>("AOELoot.Group", true);
-        range = sConfigMgr->GetOption<float>("AOELoot.Range", 55.0f);
-        maxCorpses = sConfigMgr->GetOption<uint32>("AOELoot.MaxCorpses", 20);
-
-        // Validate configuration values
-        if (range < 5.0f) range = 5.0f;
-        if (range > 100.0f) range = 100.0f;
-        if (maxCorpses < 1) maxCorpses = 1;
-        if (maxCorpses > 50) maxCorpses = 50;
-    }
+    // Fires after Player::SendLoot grants permission for a creature, once
+    // roundRobinPlayer is set and the loot window has been sent to the client.
+    void OnPlayerCreatureLootOpened(Player* player, Creature* mainCreature) override;
 };
 
 class AoeLootCommandScript : public CommandScript
@@ -119,7 +65,6 @@ public:
     static bool HandleAoeLootOnCommand(ChatHandler* handler, Optional<std::string> args);
     static bool HandleAoeLootOffCommand(ChatHandler* handler, Optional<std::string> args);
 
-    // Getters and setters for player AOE loot settings
     static bool getPlayerAoeLootEnabled(uint64 guid);
     static void setPlayerAoeLootEnabled(uint64 guid, bool mode);
     static bool hasPlayerAoeLootEnabled(uint64 guid);
@@ -131,8 +76,7 @@ private:
 void AddSC_AoeLoot()
 {
     new AOELootPlayer();
-    new AOELootServer();
     new AoeLootCommandScript();
 }
 
-#endif //MODULE_AOELOOT_H
+#endif // MODULE_AOELOOT_H

--- a/src/aoe_loot.h
+++ b/src/aoe_loot.h
@@ -21,6 +21,8 @@
 #include "Chat.h"
 #include "Config.h"
 #include "Creature.h"
+#include "Group.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "ScriptMgr.h"
 #include <list>


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Replace `AOELootServer::CanPacketReceive` (raw `CMSG_LOOT` packet interception) with the `OnPlayerCreatureLootOpened` hook, which fires after the server has already processed loot assignment and sent the loot window to the client. This is the correct, stable integration point for AOE looting.
- Move `AutoTakeCreatureLoot` into the module itself (previously depended on a pending core PR that added it to the core).
- Fix group loot item ownership: when a player opens a corpse whose round-robin slot belongs to another group member, the rightful owner's items are immediately auto-taken for them before the opener can interact with the loot window.
- Restrict AOE auto-collection to corpses assigned to the acting player via the round-robin rotation (GROUP_LOOT, ROUND_ROBIN, NEED_BEFORE_GREED). Free For All and Master Loot are unaffected.
- Remove the old loot-merging approach (which injected items into the main corpse's loot window) in favour of silently taking items per-corpse via `StoreLootItem`.
- Add `AOELoot.MaxCorpses` config option (default: 20, range: 1–50) to bound server load per loot trigger.
- Remove unused `AOELootConfig` singleton, `AOELootServer` class, and dead helper methods.

## Issues Addressed:
- Closes https://github.com/azerothcore/mod-aoe-loot/issues/63

## SOURCE:
- `Player::StoreLootItem` enforces all server-side loot validation; loot slot locking for round-robin items is enforced client-side via `LOOT_SLOT_TYPE_LOCKED`, so consuming items server-side for the rightful owner before the opener's client sends `CMSG_AUTOSTORE_LOOT_ITEM` is the correct way to protect ownership.
- `Loot::roundRobinPlayer` is set in `Loot::FillLoot` at creature death (via `Group::UpdateLooterGuid`) and reliably identifies the assigned looter for each corpse.

## Tests Performed:
- Built without errors on Windows (MSVC, C++20).
- Tested in-game on a WotLK 3.3.5a private server running AzerothCore latest master.
- Solo play: all nearby corpses auto-looted on first click; items arrive directly in bags with standard "You receive loot" messages.
- Group play (Round Robin): each player auto-receives only the corpses assigned to their round-robin slot; other members' corpses are left untouched.
- Group play (Round Robin, wrong-opener scenario): opening a corpse assigned to another player correctly sends that player's items to their bags; the opener receives nothing.
- Group play (Free For All): all members receive loot from all nearby eligible corpses.
- `.aoeloot on` / `.aoeloot off` commands work as before.
- `AOELoot.MaxCorpses` cap respected during large pulls.

## How to Test the Changes:

1. Apply this branch and recompile AzerothCore with the module enabled (`-DMODULES=static`).
2. Copy `conf/mod_aoe_loot.conf.dist` to your server's config directory. Ensure `AOELoot.Enable = 1`.
3. **Solo test:** Kill several nearby creatures, loot one — verify all eligible corpses within `AOELoot.Range` are automatically looted without opening each one individually.
4. **Group round-robin test:** Form a group of two characters, set loot method to Round Robin. Kill several creatures. Have one player loot — verify each player only auto-collects the corpses assigned to them by the rotation (items appear in bags without clicking those corpses).
5. **Wrong-opener protection test:** With Round Robin active, have the *non-assigned* player manually open a corpse belonging to the other player. Verify: the rightful owner's items appear in their bags immediately; the opener's loot window shows no items (or only FFA items if any).
6. **Free For All test:** Set group loot to Free For All. Verify all nearby corpses are auto-collected by any group member who loots.
7. Check server log for any errors or warnings related to `mod-aoe-loot`.